### PR TITLE
Fix permission problem with yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 
 # Try it out
 
+**Requires yarn**
+
 1. `docker-compose build`
+1. `./pre-run`
 1. `docker-compose up`
+

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,4 +4,4 @@ ENV PORT=4500
 
 WORKDIR /app
 
-ENTRYPOINT yarn && yarn start
+ENTRYPOINT yarn start

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       - '4000:4000'
     volumes:
       - './server:/app'
+
   client:
     build:
       context: ./client

--- a/pre-up
+++ b/pre-up
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Pretty much what it does is yarn install on server and client before docker-compose up
+ROOT=$PWD
+cd $ROOT/server
+yarn
+
+cd $ROOT/client
+yarn
+
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,8 @@
 FROM node:14.17.3
 EXPOSE 4000
 
-# Do environmental setup here
-# Installing node modules
 WORKDIR /app
 
-ENTRYPOINT yarn && yarn dev
+ENTRYPOINT yarn dev
 
 


### PR DESCRIPTION
`docker-compose up` overrides the permission of the `node_modules` when it runs `yarn install`
Added a `pre-up` script to do `yarn install` within the host.

Im not happy with this solution, so lmk if there are any better ways to get around this problem.


- Closes #21  